### PR TITLE
Mobile piano fix

### DIFF
--- a/src/lib/App.svelte
+++ b/src/lib/App.svelte
@@ -76,6 +76,7 @@
      display: flex;
      justify-content: space-between;
      letter-spacing: 0.2rem;
+     user-select: none;
  }
  /* latin-ext */
  @font-face {

--- a/src/lib/piano/Piano.svelte
+++ b/src/lib/piano/Piano.svelte
@@ -119,7 +119,6 @@
             class:whiteKey="{isWhite}"
             class:blackKey="{!isWhite}"
             class:down="{notesDown[note]?.keyboard || notesDown[note]?.pointer}"
-            draggable="false"
             on:pointerdown="{() => pressNote(note, 'pointer')}"
             on:pointerup="{() => releaseNote(note, 'pointer')}"
             on:mouseenter="{(ev) => {if (ev.buttons > 0) pressNote(note, 'pointer');}}"


### PR DESCRIPTION
The draggable attribute was actually doing nothing. Disabling text-selection on the footer should make the piano usable on mobile again.