### PR TITLE
netlify: Hide deploy preview bar

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,4 +28,8 @@
  input, textarea, select {
      font-family: inherit;
  }
+ /* netlify deploy preview bar */
+ div[data-netlify-deploy-id] {
+     display: none
+ }
 </style>


### PR DESCRIPTION
Hide the bar that appears at the bottom of the netlify previews.

Its features may be slightly useful but I think it's ugly and just gets in the way of normal users.