### PR TITLE
Changed App shadow from filter to box-shadow

### DIFF
--- a/src/lib/App.svelte
+++ b/src/lib/App.svelte
@@ -61,10 +61,10 @@
      padding: 0.5rem 1rem;
      border-radius: 1em;
      background: var(--bg-color);
-     --bg-color: #0008;
+     --bg-color: #000000A2;
      backdrop-filter: blur(5px);
      color: white;
-     filter: drop-shadow(4px 4px 10px #3338);
+     box-shadow: 0 0 10px #3338;
  }
  @media (max-width: 680px) {
      .App {


### PR DESCRIPTION
For #70

Lighthouse says the labels directly on the background have too low of a contrast ratio. The text is near white, the background is `#0008`. I think this is failing because the transparency is too low to guarantee contrast with any arbitrary background.

Before the PR, the App's `filter: box-shadow` was drawing behind the transparent background, darkening the App. Lighthouse doesn't understand this, or assumes some browsers won't have support so it ignores filters. Replacing the filter with a box-shadow allows us to darken the background color with almost no visual change.